### PR TITLE
Add Atom feed link to head

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -112,4 +112,9 @@
   {% unless site.theme_mode %}
     {% include mode-toggle.html %}
   {% endunless %}
+
+  <link rel="alternate"
+        type="application/atom+xml"
+        title="{{ site.title }}"
+        href="{{ '/feed.xml' | relative_url }}">
 </head>


### PR DESCRIPTION
## Summary
- include RSS feed link in the HTML head section

## Testing
- `bundle install`
- `bundle exec jekyll b`

------
https://chatgpt.com/codex/tasks/task_e_68472b7fd5608322ae3f06c2bb0d81a2